### PR TITLE
chore: migrate from rtx to mise for tool versioning

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
 [tools]
+just = "1.43.0"
 pre-commit = "latest"
 ruff = "latest"
+uv = "0.7.2"


### PR DESCRIPTION
## Summary

- Migrate tool version management from rtx to mise
- Rename `.rtx.toml` to `mise.toml`
- Pin specific versions for `just` and `uv` tools for consistency

## Test plan

- [x] Pre-commit hooks pass
- Verify mise correctly loads tool versions with `mise install`